### PR TITLE
Create orchestrator

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 version: "3.3"
 services:
-  comparator:
+  orchestrator:
     ports:
       - "8080:8080"
     build:
       context: ./
-      dockerfile: comparator/Dockerfile
+      dockerfile: orchestrator/Dockerfile
     networks:
       - maratona-net
   compiler:

--- a/model/execution.go
+++ b/model/execution.go
@@ -1,7 +1,34 @@
 package model
 
+import (
+	"gorm.io/gorm"
+	"mime/multipart"
+)
+
 type ExecutionResult struct {
 	TestName string `json:"testName"`
 	Status   string `json:"status"`
 	Message  string `json:"message"`
+}
+
+type SubmissionForm struct {
+	Language    string                `form:"language"`
+	Source      *multipart.FileHeader `form:"source"`
+	ChallengeID string                `form:"challengeID"`
+}
+
+type Challenge struct {
+	gorm.Model
+	Title       string
+	TimeLimit   int
+	MemoryLimit int
+	Inputs      []TestFile `gorm:"ForeignKey:ChallengeID"`
+	Outputs     []TestFile `gorm:"ForeignKey:ChallengeID"`
+}
+
+type TestFile struct {
+	gorm.Model
+	Filename    string
+	Content     []byte
+	ChallengeID uint
 }

--- a/orchestrator/Dockerfile
+++ b/orchestrator/Dockerfile
@@ -3,7 +3,7 @@ EXPOSE 8080
 WORKDIR /go/src/app
 COPY go.sum go.mod ./
 RUN go mod download
-COPY errors/ errors/
 COPY model/ model/
-COPY orm/ orm/
-CMD ["go", "run", "orm/main.go"]
+COPY errors/ errors/
+COPY orchestrator/ orchestrator/
+CMD ["go", "run", "orchestrator/main.go"]

--- a/orchestrator/main.go
+++ b/orchestrator/main.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"mime/multipart"
+	"net/http"
+
+	"github.com/go-martini/martini"
+	httpErrors "github.com/maratona-run-time/Maratona-Runtime/errors"
+	model "github.com/maratona-run-time/Maratona-Runtime/model"
+	"github.com/martini-contrib/binding"
+)
+
+var getChallengeError = errors.New("Error getting challenge")
+var verdictResponseError = errors.New("Error on verdict response")
+
+func createFileField(writer *multipart.Writer, fieldName string, file *multipart.FileHeader) error {
+	field, err := writer.CreateFormFile(fieldName, file.Filename)
+	if err != nil {
+		return err
+	}
+	content, err := file.Open()
+	if err != nil {
+		return err
+	}
+	io.Copy(field, content)
+	defer content.Close()
+	return nil
+}
+func createTestFileField(writer *multipart.Writer, fieldName string, files []model.TestFile) error {
+	for _, file := range files {
+		field, err := writer.CreateFormFile(fieldName, file.Filename)
+		if err != nil {
+			return err
+		}
+		_, err = field.Write(file.Content)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func getChallengeInfo(challengeID string) (model.Challenge, error) {
+	req, err := http.NewRequest("GET", fmt.Sprintf("http://orm:8080/challenge/%v", challengeID), new(bytes.Buffer))
+	if err != nil {
+		return model.Challenge{}, err
+	}
+	client := &http.Client{}
+	res, err := client.Do(req)
+	if err != nil {
+		return model.Challenge{}, err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return model.Challenge{}, getChallengeError
+	}
+
+	var challenge model.Challenge
+	binary, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return model.Challenge{}, err
+	}
+	err = json.Unmarshal(binary, &challenge)
+	return challenge, err
+}
+
+func callVerdict(challenge model.Challenge, form model.SubmissionForm) ([]byte, error) {
+	buffer := new(bytes.Buffer)
+	writer := multipart.NewWriter(buffer)
+
+	languageField, err := writer.CreateFormField("language")
+	if err != nil {
+		return nil, err
+	}
+	languageField.Write([]byte(form.Language))
+
+	err = createFileField(writer, "source", form.Source)
+	if err != nil {
+		return nil, err
+	}
+
+	err = createTestFileField(writer, "inputs", challenge.Inputs)
+	if err != nil {
+		return nil, err
+	}
+
+	err = createTestFileField(writer, "outputs", challenge.Outputs)
+	if err != nil {
+		return nil, err
+	}
+
+	writer.Close()
+
+	req, err := http.NewRequest("POST", "http://verdict:8080", buffer)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	client := &http.Client{}
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return nil, verdictResponseError
+	}
+
+	binary, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+	return binary, nil
+}
+
+func main() {
+	m := martini.Classic()
+	m.Post("/", binding.MultipartForm(model.SubmissionForm{}), func(rs http.ResponseWriter, rq *http.Request, form model.SubmissionForm) {
+		challenge, err := getChallengeInfo(form.ChallengeID)
+		if err != nil {
+			msg := fmt.Sprintf("Could not find challenge %v", form.ChallengeID)
+			httpErrors.WriteResponse(rs, http.StatusBadRequest, msg, err)
+		}
+
+		verdictResponse, err := callVerdict(challenge, form)
+		if err != nil {
+			msg := "Could not get response from verdict"
+			httpErrors.WriteResponse(rs, http.StatusBadRequest, msg, err)
+			return
+		}
+
+		rs.Write(verdictResponse)
+	})
+	m.RunOnAddr(":8080")
+}

--- a/orm/src/orm.go
+++ b/orm/src/orm.go
@@ -5,22 +5,9 @@ import (
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 	"sync"
+
+	model "github.com/maratona-run-time/Maratona-Runtime/model"
 )
-
-type Challenge struct {
-	gorm.Model
-	Title       string
-	TimeLimit   int
-	MemoryLimit int
-	Inputs      []Input `gorm:"ForeignKey:ChallengeID"`
-}
-
-type Input struct {
-	gorm.Model
-	Filename    string
-	Content     []byte
-	ChallengeID uint
-}
 
 var db *gorm.DB = nil
 var once sync.Once
@@ -37,31 +24,31 @@ func dbConnect() *gorm.DB {
 		if db, err = gorm.Open(postgres.Open(dsn), &gorm.Config{}); err != nil {
 			panic(err)
 		}
-		if err = db.AutoMigrate(&Input{}); err != nil {
+		if err = db.AutoMigrate(&model.TestFile{}); err != nil {
 			panic(err)
 		}
-		if err = db.AutoMigrate(&Challenge{}); err != nil {
+		if err = db.AutoMigrate(&model.Challenge{}); err != nil {
 			panic(err)
 		}
 	})
 	return db
 }
 
-func CreateChallenge(challenge *Challenge) error {
+func CreateChallenge(challenge *model.Challenge) error {
 	db := dbConnect()
 	return db.Create(challenge).Error
 }
 
-func FindChallenge(id string) (Challenge, error) {
+func FindChallenge(id string) (model.Challenge, error) {
 	db := dbConnect()
-	var challenge Challenge
-	err := db.Preload("Inputs").First(&challenge, id).Error
+	var challenge model.Challenge
+	err := db.Preload("Inputs").Preload("Outputs").First(&challenge, id).Error
 	return challenge, err
 }
 
-func FindAllChallenges() ([]Challenge, error) {
+func FindAllChallenges() ([]model.Challenge, error) {
 	db := dbConnect()
-	var challenges []Challenge
-	err := db.Preload("Inputs").Find(&challenges).Error
+	var challenges []model.Challenge
+	err := db.Preload("Inputs").Preload("Outputs").Find(&challenges).Error
 	return challenges, err
 }


### PR DESCRIPTION
Add route `POST /` that receives language, source and a challengeID. It
talks to `orm` to get the challenge information and creates a request
that is sent to `verdict`.

comparator was removed from docker-compose and orchestrator uses port
8080 instead.

Add `Outputs` field to Challenge.