### PR TITLE
Refactoring day changes

### DIFF
--- a/compiler/main.go
+++ b/compiler/main.go
@@ -18,7 +18,7 @@ import (
 
 type FileForm struct {
 	Language string                `form:"language"`
-	Program  *multipart.FileHeader `form:"program"`
+	Source   *multipart.FileHeader `form:"source"`
 }
 
 var sourceFileName = map[string]string{
@@ -42,7 +42,7 @@ func createCompilerServer(logger zerolog.Logger) *martini.ClassicMartini {
 			utils.WriteResponse(rs, http.StatusBadRequest, msg, createErr)
 			return
 		}
-		program, pErr := req.Program.Open()
+		program, pErr := req.Source.Open()
 		if pErr != nil {
 			msg := "An error occurred while trying to open the received program"
 			logger.Error().

--- a/compiler/main_test.go
+++ b/compiler/main_test.go
@@ -13,33 +13,21 @@ import (
 	"github.com/maratona-run-time/Maratona-Runtime/utils"
 )
 
-func createRequestForm(writer *multipart.Writer, language, filepath string) error {
-
-	languageField, err := writer.CreateFormField("language")
+func createRequestForm(writer *multipart.Writer, language, filePath string) error {
+	fieldName := "language"
+	err := utils.CreateFormField(writer, fieldName, language)
 	if err != nil {
 		return err
 	}
-	_, err = languageField.Write([]byte(language))
-	if err != nil {
-		return err
-	}
-
-	content, err := ioutil.ReadFile(filepath)
-	if err != nil {
-		return err
-	}
-	field, err := writer.CreateFormFile("program", "source")
-	if err != nil {
-		return err
-	}
-	_, err = field.Write(content)
-	return err
+	fieldName = "program"
+	fileName := "source"
+	return utils.CreateFormFileFromFilePath(writer, fieldName, fileName, filePath)
 }
 
-func createRequest(t *testing.T, language, filepath string) *http.Request {
+func createRequest(t *testing.T, language, filePath string) *http.Request {
 	buffer := new(bytes.Buffer)
 	writer := multipart.NewWriter(buffer)
-	err := createRequestForm(writer, language, filepath)
+	err := createRequestForm(writer, language, filePath)
 	if err != nil {
 		t.Error("could not create request form")
 	}

--- a/compiler/main_test.go
+++ b/compiler/main_test.go
@@ -19,7 +19,7 @@ func createRequestForm(writer *multipart.Writer, language, filePath string) erro
 	if err != nil {
 		return err
 	}
-	fieldName = "program"
+	fieldName = "source"
 	fileName := "source"
 	return utils.CreateFormFileFromFilePath(writer, fieldName, fileName, filePath)
 }

--- a/executor/main_test.go
+++ b/executor/main_test.go
@@ -22,7 +22,7 @@ func resultEqual(a, b model.ExecutionResult) bool {
 	}
 }
 
-func addFile(writer *multipart.Writer, filePath string, fieldName string) error {
+func addFile(writer *multipart.Writer, filePath, fieldName string) error {
 	fileName := path.Base(filePath)
 	content, err := ioutil.ReadFile(filePath)
 	if err != nil {

--- a/executor/main_test.go
+++ b/executor/main_test.go
@@ -22,27 +22,17 @@ func resultEqual(a, b model.ExecutionResult) bool {
 	}
 }
 
-func addFile(writer *multipart.Writer, filePath, fieldName string) error {
-	fileName := path.Base(filePath)
-	content, err := ioutil.ReadFile(filePath)
-	if err != nil {
-		return err
-	}
-	field, err := writer.CreateFormFile(fieldName, fileName)
-	if err != nil {
-		return err
-	}
-	_, err = field.Write(content)
-	return err
-}
-
 func createRequestForm(writer *multipart.Writer, filePath string, inputPaths []string) error {
-	err := addFile(writer, filePath, "binary")
+	fieldName := "binary"
+	fileName := path.Base(filePath)
+	err := utils.CreateFormFileFromFilePath(writer, fieldName, fileName, filePath)
 	if err != nil {
 		return err
 	}
 	for _, inputPath := range inputPaths {
-		err := addFile(writer, inputPath, "inputs")
+		fieldName = "inputs"
+		fileName = path.Base(inputPath)
+		err = utils.CreateFormFileFromFilePath(writer, fieldName, fileName, inputPath)
 		if err != nil {
 			return err
 		}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.15
 require (
 	github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0 // indirect
 	github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab
-	github.com/google/go-cmp v0.5.4
 	github.com/jackc/pgx/v4 v4.9.2 // indirect
 	github.com/martini-contrib/binding v0.0.0-20160701174519-05d3e151b6cf
 	github.com/rs/zerolog v1.20.0

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,6 @@ github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab/go.mod h1:/P9AE
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gofrs/uuid v3.2.0+incompatible h1:y12jRkkFxsd7GpqdSZ+/KCs/fJbqpEXSGd4+jfEaewE=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
-github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
-github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/jackc/chunkreader v1.0.0 h1:4s39bBR8ByfqH+DKm8rQA3E1LHZWB9XWcrz8fqaZbe0=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=

--- a/orchestrator/main.go
+++ b/orchestrator/main.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"mime/multipart"
 	"net/http"
@@ -19,26 +18,9 @@ import (
 var getChallengeError = errors.New("Error getting challenge")
 var verdictResponseError = errors.New("Error on verdict response")
 
-func createFileField(writer *multipart.Writer, fieldName string, file *multipart.FileHeader) error {
-	field, err := writer.CreateFormFile(fieldName, file.Filename)
-	if err != nil {
-		return err
-	}
-	content, err := file.Open()
-	if err != nil {
-		return err
-	}
-	io.Copy(field, content)
-	defer content.Close()
-	return nil
-}
 func createTestFileField(writer *multipart.Writer, fieldName string, files []model.TestFile) error {
 	for _, file := range files {
-		field, err := writer.CreateFormFile(fieldName, file.Filename)
-		if err != nil {
-			return err
-		}
-		_, err = field.Write(file.Content)
+		err := utils.CreateFormFileFromContent(writer, fieldName, file.Content, file.Filename)
 		if err != nil {
 			return err
 		}
@@ -80,7 +62,7 @@ func callVerdict(challenge model.Challenge, form model.SubmissionForm) ([]byte, 
 	}
 	languageField.Write([]byte(form.Language))
 
-	err = createFileField(writer, "source", form.Source)
+	err = utils.CreateFormFileFromFileHeader(writer, "source", form.Source)
 	if err != nil {
 		return nil, err
 	}

--- a/orchestrator/main.go
+++ b/orchestrator/main.go
@@ -56,11 +56,11 @@ func callVerdict(challenge model.Challenge, form model.SubmissionForm) ([]byte, 
 	buffer := new(bytes.Buffer)
 	writer := multipart.NewWriter(buffer)
 
-	languageField, err := writer.CreateFormField("language")
+	fieldName := "language"
+	err := utils.CreateFormField(writer, fieldName, form.Language)
 	if err != nil {
 		return nil, err
 	}
-	languageField.Write([]byte(form.Language))
 
 	err = utils.CreateFormFileFromFileHeader(writer, "source", form.Source)
 	if err != nil {

--- a/utils/writer.go
+++ b/utils/writer.go
@@ -1,0 +1,52 @@
+package utils
+
+import (
+	"io/ioutil"
+	"mime/multipart"
+)
+
+// CreateFormFileFromContent creates file field named 'fieldName' with the value of 'content'
+func CreateFormFileFromContent(writer *multipart.Writer, fieldName string, content []byte, fileName string) error {
+	field, err := writer.CreateFormFile(fieldName, fileName)
+	if err != nil {
+		return err
+	}
+	_, err = field.Write(content)
+	return err
+}
+
+// CreateFormFileFromFileHeader creates file field named 'fieldName' with the contents of 'file'.
+func CreateFormFileFromFileHeader(writer *multipart.Writer, fieldName string, file *multipart.FileHeader) error {
+	contentFile, err := file.Open()
+	if err != nil {
+		return err
+	}
+	defer contentFile.Close()
+	content, err := ioutil.ReadAll(contentFile)
+	if err != nil {
+		return err
+	}
+	return CreateFormFileFromContent(writer, fieldName, content, file.Filename)
+}
+
+// CreateFormFileFromFilePath creates file field named 'fieldName' with the content of a file on 'filePath'
+func CreateFormFileFromFilePath(writer *multipart.Writer, fieldName, fileName, filePath string) error {
+	content, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return err
+	}
+	return CreateFormFileFromContent(writer, fieldName, content, fileName)
+}
+
+// CreateFormField creates a field named 'fieldName' with the content 'fieldContent'
+func CreateFormField(writer *multipart.Writer, fieldName, fieldContent string) error {
+	field, err := writer.CreateFormField(fieldName)
+	if err != nil {
+		return err
+	}
+	_, err = field.Write([]byte(fieldContent))
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/verdict/main.go
+++ b/verdict/main.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"io"
 	"io/ioutil"
 	"mime/multipart"
 	"net/http"
@@ -33,13 +32,13 @@ func handleCompiling(language string, source *multipart.FileHeader) ([]byte, err
 	buffer := new(bytes.Buffer)
 	writer := multipart.NewWriter(buffer)
 
-	languageField, err := writer.CreateFormField("language")
+	fieldName := "language"
+	err := utils.CreateFormField(writer, fieldName, language)
 	if err != nil {
 		return nil, err
 	}
-	languageField.Write([]byte(language))
 
-	fieldName := "source"
+	fieldName = "source"
 	err = utils.CreateFormFileFromFileHeader(writer, fieldName, source)
 	if err != nil {
 		return nil, err
@@ -70,20 +69,15 @@ func handleCompiling(language string, source *multipart.FileHeader) ([]byte, err
 	return binary, nil
 }
 
-func handleExecute(binary string, inputs []*multipart.FileHeader) ([]model.ExecutionResult, error) {
+func handleExecute(binaryFilePath string, inputs []*multipart.FileHeader) ([]model.ExecutionResult, error) {
 	buffer := new(bytes.Buffer)
 	writer := multipart.NewWriter(buffer)
-
-	binaryField, err := writer.CreateFormFile("binary", binary)
+	fieldName := "binary"
+	fileName := "binary"
+	err := utils.CreateFormFileFromFilePath(writer, fieldName, fileName, binaryFilePath)
 	if err != nil {
 		return nil, err
 	}
-	binaryFile, err := os.Open(binary)
-	if err != nil {
-		return nil, err
-	}
-	defer binaryFile.Close()
-	io.Copy(binaryField, binaryFile)
 
 	for _, input := range inputs {
 		err = utils.CreateFormFileFromFileHeader(writer, "inputs", input)

--- a/verdict/main.go
+++ b/verdict/main.go
@@ -39,7 +39,8 @@ func handleCompiling(language string, source *multipart.FileHeader) ([]byte, err
 	}
 	languageField.Write([]byte(language))
 
-	err = utils.CreateFormFileFromFileHeader(writer, "program", source)
+	fieldName := "source"
+	err = utils.CreateFormFileFromFileHeader(writer, fieldName, source)
 	if err != nil {
 		return nil, err
 	}

--- a/verdict/main.go
+++ b/verdict/main.go
@@ -9,11 +9,11 @@ import (
 	"mime/multipart"
 	"net/http"
 	"os"
-	"strings"
 
 	"github.com/go-martini/martini"
 	model "github.com/maratona-run-time/Maratona-Runtime/model"
 	"github.com/maratona-run-time/Maratona-Runtime/utils"
+	"github.com/maratona-run-time/Maratona-Runtime/verdict/src"
 	"github.com/martini-contrib/binding"
 
 	"github.com/rs/zerolog"
@@ -29,20 +29,6 @@ type VerdictForm struct {
 	Outputs  []*multipart.FileHeader `form:"outputs"`
 }
 
-func createFileField(writer *multipart.Writer, fieldName string, file *multipart.FileHeader) error {
-	field, err := writer.CreateFormFile(fieldName, file.Filename)
-	if err != nil {
-		return err
-	}
-	content, err := file.Open()
-	if err != nil {
-		return err
-	}
-	io.Copy(field, content)
-	defer content.Close()
-	return nil
-}
-
 func handleCompiling(language string, source *multipart.FileHeader) ([]byte, error) {
 	buffer := new(bytes.Buffer)
 	writer := multipart.NewWriter(buffer)
@@ -53,7 +39,7 @@ func handleCompiling(language string, source *multipart.FileHeader) ([]byte, err
 	}
 	languageField.Write([]byte(language))
 
-	err = createFileField(writer, "program", source)
+	err = utils.CreateFormFileFromFileHeader(writer, "program", source)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +85,7 @@ func handleExecute(binary string, inputs []*multipart.FileHeader) ([]model.Execu
 	io.Copy(binaryField, binaryFile)
 
 	for _, input := range inputs {
-		err = createFileField(writer, "inputs", input)
+		err = utils.CreateFormFileFromFileHeader(writer, "inputs", input)
 		if err != nil {
 			return nil, err
 		}
@@ -124,10 +110,6 @@ func handleExecute(binary string, inputs []*multipart.FileHeader) ([]model.Execu
 		return nil, err
 	}
 	return *executionResult, nil
-}
-
-func compare(expectedOutput string, programOutput string) bool {
-	return strings.EqualFold(programOutput, expectedOutput)
 }
 
 func main() {
@@ -155,7 +137,7 @@ func main() {
 			rs.WriteHeader(http.StatusOK)
 			logger.Debug().
 				Msg("Compilation Error")
-			return "CE" // Compilation Error
+			return "CE"
 		}
 		if compilerErr != nil {
 			msg := "Failed Judgment\nAn error occurred while trying to compile the file '" + f.Source.Filename + "' on the language '" + f.Language + "'"
@@ -165,7 +147,9 @@ func main() {
 				Msg(msg)
 			return ""
 		}
-		writeErr := ioutil.WriteFile("binary", binary, 0777)
+
+		const binaryFileName = "binary"
+		writeErr := ioutil.WriteFile(binaryFileName, binary, 0777)
 		if writeErr != nil {
 			msg := "Failed judgment\nAn error occurred while trying to create a local copy of the binary compilation of '" + f.Source.Filename + "'"
 			utils.WriteResponse(rs, http.StatusInternalServerError, msg, writeErr)
@@ -174,7 +158,7 @@ func main() {
 				Msg(msg)
 			return ""
 		}
-		result, executorErr := handleExecute("binary", f.Inputs)
+		results, executorErr := handleExecute(binaryFileName, f.Inputs)
 		if executorErr != nil {
 			msg := "Failed judgment\nAn error occurred while trying to execute the program with the received input files"
 			utils.WriteResponse(rs, http.StatusInternalServerError, msg, executorErr)
@@ -191,32 +175,13 @@ func main() {
 			outputs[outputName] = out
 		}
 
-		for _, testExecution := range result {
-			if testExecution.Status != "OK" {
-				logger.Info().Msg("Judgment finished sentence " + testExecution.Status + " " + testExecution.TestName)
-				return testExecution.Status + " " + testExecution.TestName
-			}
+		result, err := verdict.Judge(results, outputs, logger)
 
-			testName := testExecution.TestName[len("inputs/") : len(testExecution.TestName)-len(".in")]
-			expectedOutputContent, err := outputs[testName].Open()
-			if err != nil {
-				msg := "Failed judgment\nAn error occurred while trying to open the output file named '" + testName + "'"
-				utils.WriteResponse(rs, http.StatusBadRequest, msg, err)
-				logger.Error().
-					Err(err).
-					Msg(msg)
-				return ""
-			}
-			defer expectedOutputContent.Close()
-			byteExpectedOutput, err := ioutil.ReadAll(expectedOutputContent)
-			expectedOutput := string(byteExpectedOutput)
-			if compare(testExecution.Message, expectedOutput) == false {
-				logger.Info().Msg("Judgment finished sentence Wrong Answer")
-				return "WA" + " " + testExecution.TestName
-			}
+		if err != nil {
+			utils.WriteResponse(rs, http.StatusBadRequest, "", err)
+			return ""
 		}
-		logger.Info().Msg("Judgment finished sentence Accepted")
-		return "AC"
+		return result
 	})
 	m.RunOnAddr(":8080")
 }

--- a/verdict/src/verdict.go
+++ b/verdict/src/verdict.go
@@ -1,0 +1,44 @@
+package verdict
+
+import (
+	"fmt"
+	"io/ioutil"
+	"mime/multipart"
+	"strings"
+
+	"github.com/maratona-run-time/Maratona-Runtime/model"
+
+	"github.com/rs/zerolog"
+)
+
+func compare(expectedOutput string, programOutput string) bool {
+	return strings.EqualFold(programOutput, expectedOutput)
+}
+
+func Judge(result []model.ExecutionResult, outputs map[string]*multipart.FileHeader, logger zerolog.Logger) (string, error) {
+	for _, testExecution := range result {
+		if testExecution.Status != "OK" {
+			logger.Info().Msg("Judgment finished sentence " + testExecution.Status + " " + testExecution.TestName)
+			return testExecution.Status + " " + testExecution.TestName, nil
+		}
+
+		testName := testExecution.TestName[len("inputs/") : len(testExecution.TestName)-len(".in")]
+		expectedOutputContent, err := outputs[testName].Open()
+		if err != nil {
+			msg := "Failed judgment\nAn error occurred while trying to open the output file named '" + testName + "'"
+			logger.Error().
+				Err(err).
+				Msg(msg)
+			return "", fmt.Errorf(msg)
+		}
+		defer expectedOutputContent.Close()
+		byteExpectedOutput, err := ioutil.ReadAll(expectedOutputContent)
+		expectedOutput := string(byteExpectedOutput)
+		if compare(testExecution.Message, expectedOutput) == false {
+			logger.Info().Msg("Judgment finished sentence Wrong Answer")
+			return "WA" + " " + testExecution.TestName, nil
+		}
+	}
+	logger.Info().Msg("Judgment finished sentence Accepted")
+	return "AC", nil
+}


### PR DESCRIPTION
- Change "Program" to "Source" on the field form received by the compiler. This matches the "Source" field also used by the executor.
- Extract functions that change form-data requests to a file named `writer.go`.
- Extract verdict server code to a verdict.go file.