### PR TITLE
Make docker images smaller

### DIFF
--- a/compiler/Dockerfile
+++ b/compiler/Dockerfile
@@ -1,10 +1,13 @@
-FROM golang:alpine
-EXPOSE 8080
+FROM golang:alpine AS build
 WORKDIR /go/src/app
-RUN apk add g++
-RUN apk add gcc
 COPY go.sum go.mod ./
 RUN go mod download
 COPY utils/ utils/
 COPY compiler/ compiler/
-CMD ["go", "run", "compiler/main.go"]
+RUN go build compiler/main.go
+
+FROM alpine
+WORKDIR /go/src/app
+RUN apk add g++ gcc go
+COPY --from=build /go/src/app/main .
+CMD ["./main"]

--- a/executor/Dockerfile
+++ b/executor/Dockerfile
@@ -9,6 +9,6 @@ RUN go build executor/main.go
 
 FROM alpine
 WORKDIR /go/src/app
-RUN apk add go gcc g++ python3
+RUN apk add binutils python3
 COPY --from=build /go/src/app/main .
 CMD ["./main"]

--- a/executor/Dockerfile
+++ b/executor/Dockerfile
@@ -1,10 +1,14 @@
-FROM golang:alpine
-EXPOSE 8080
+FROM golang:alpine AS build
 WORKDIR /go/src/app
-RUN apk add gcc g++ python3
 COPY go.sum go.mod ./
 RUN go mod download
 COPY model/ model/
 COPY utils/ utils/
 COPY executor/ executor/
-CMD ["go", "run", "executor/main.go"]
+RUN go build executor/main.go
+
+FROM alpine
+WORKDIR /go/src/app
+RUN apk add go gcc g++ python3
+COPY --from=build /go/src/app/main .
+CMD ["./main"]

--- a/orchestrator/Dockerfile
+++ b/orchestrator/Dockerfile
@@ -1,9 +1,13 @@
-FROM golang:alpine
-EXPOSE 8080
+FROM golang:alpine AS build
 WORKDIR /go/src/app
 COPY go.sum go.mod ./
 RUN go mod download
 COPY model/ model/
 COPY utils/ utils/
 COPY orchestrator/ orchestrator/
-CMD ["go", "run", "orchestrator/main.go"]
+RUN go build orchestrator/main.go
+
+FROM alpine
+WORKDIR /go/src/app
+COPY --from=build /go/src/app/main .
+CMD ["./main"]

--- a/orm/Dockerfile
+++ b/orm/Dockerfile
@@ -1,9 +1,13 @@
-FROM golang:alpine
-EXPOSE 8080
+FROM golang:alpine AS build
 WORKDIR /go/src/app
 COPY go.sum go.mod ./
 RUN go mod download
 COPY utils/ utils/
 COPY model/ model/
 COPY orm/ orm/
-CMD ["go", "run", "orm/main.go"]
+RUN go build orm/main.go
+
+FROM alpine
+WORKDIR /go/src/app
+COPY --from=build /go/src/app/main .
+CMD ["./main"]

--- a/verdict/Dockerfile
+++ b/verdict/Dockerfile
@@ -1,9 +1,13 @@
-FROM golang:alpine
-EXPOSE 8080
+FROM golang:alpine AS build
 WORKDIR /go/src/app
 COPY go.sum go.mod ./
 RUN go mod download
 COPY model/ model/
 COPY utils/ utils/
 COPY verdict/ verdict/
-CMD ["go", "run", "verdict/main.go"]
+RUN go build verdict/main.go
+
+FROM alpine
+WORKDIR /go/src/app
+COPY --from=build /go/src/app/main .
+CMD ["./main"]


### PR DESCRIPTION
Uses a build layer to download module dependencies and build main.go, then copies the binary to an alpine image.
Also removes the layer "EXPOSE 8080", not necessary for the docker-compose and K8s deployments.

New images:
![image](https://user-images.githubusercontent.com/12179028/103162543-a57af300-47d0-11eb-947e-099c5e3ef870.png)


Earlier image sizes (from DockerHub):
![image](https://user-images.githubusercontent.com/12179028/103162534-83817080-47d0-11eb-8bbf-6201b6a0d5c1.png)

Still could use some improvement on the compiler and executor, the bulkier images that require g++, gcc, python and go. 