### PR TITLE
Create action that builds and pushes images to registry

### DIFF
--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -1,0 +1,29 @@
+name: Build and push docker images
+on:
+  push:
+    branches: 
+      - '**' # Every branch
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Login to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - run: docker-compose build
+    - run: docker tag compiler mruntime/compiler
+    - run: docker push mruntime/compiler
+    - run: docker tag executor mruntime/executor
+    - run: docker push mruntime/executor
+    - run: docker tag orchestrator mruntime/orchestrator
+    - run: docker push mruntime/orchestrator
+    - run: docker tag orm mruntime/orm
+    - run: docker push mruntime/orm
+    - run: docker tag verdict mruntime/verdict
+    - run: docker push mruntime/verdict 

--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -16,8 +16,8 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - uses: actions/checkout@v2
     - name: Builds docker images
-      uses: actions/checkout@v2
       run: docker-compose build
     - run: docker tag compiler mruntime/compiler
     - run: docker push mruntime/compiler

--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -16,7 +16,9 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
-    - run: docker-compose build
+    - name: Builds docker images
+      uses: actions/checkout@v2
+      run: docker-compose build
     - run: docker tag compiler mruntime/compiler
     - run: docker push mruntime/compiler
     - run: docker tag executor mruntime/executor

--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,5 @@
 
 # hidden files
 .*
+!.github
 !.travis.yml


### PR DESCRIPTION
Now every push will fire a GitHub action to build every docker image (using docker-compose) and push it to the "mruntime" registry at DockerHub (https://hub.docker.com/orgs/mruntime/repositories).