### PR TITLE
Save submission verdict after judging

### DIFF
--- a/executor/main_test.go
+++ b/executor/main_test.go
@@ -117,7 +117,7 @@ func TestExecutorServer(t *testing.T) {
 				},
 				{
 					TestName: "inputs/4.in",
-					Status:   "TLE",
+					Status:   model.TIME_LIMIT_EXCEEDED,
 					Message:  "Tempo limite excedido",
 				},
 			},
@@ -132,7 +132,7 @@ func TestExecutorServer(t *testing.T) {
 			expectedResult: []model.ExecutionResult{
 				{
 					TestName: "inputs/1.in",
-					Status:   "RTE",
+					Status:   model.RUNTIME_ERROR,
 					Message:  "exit status 1",
 				},
 			},

--- a/executor/src/executor.go
+++ b/executor/src/executor.go
@@ -60,15 +60,15 @@ func Execute(path string,
 
 		select {
 		case <-ctx.Done():
-			res = append(res, model.ExecutionResult{inputFileName, "TLE", "Time limit exceeded"})
+			res = append(res, model.ExecutionResult{TestName: inputFileName, Status: model.TIME_LIMIT_EXCEEDED, Message: "Time limit exceeded"})
 			logger.Debug().Msg("Time limit exceeded")
 			return res
 		case err := <-errorOutput:
-			res = append(res, model.ExecutionResult{inputFileName, "RTE", err.Error()})
-			logger.Debug().Msg("Run time error")
+			res = append(res, model.ExecutionResult{TestName: inputFileName, Status: model.RUNTIME_ERROR, Message: err.Error()})
+			logger.Debug().Msg("Runtime error")
 			return res
 		case out := <-output:
-			res = append(res, model.ExecutionResult{inputFileName, "OK", string(out)})
+			res = append(res, model.ExecutionResult{TestName: inputFileName, Status: "OK", Message: string(out)})
 		}
 	}
 	logger.Debug().Msg("Executions finished")

--- a/executor/src/executor_test.go
+++ b/executor/src/executor_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/maratona-run-time/Maratona-Runtime/model"
 	"github.com/maratona-run-time/Maratona-Runtime/utils"
 )
 
@@ -21,15 +22,15 @@ func TestExecuteOK(t *testing.T) {
 func TestExecuteTLE(t *testing.T) {
 	logger := utils.InitDummyLogger()
 	status := Execute("./tests/tle.sh", "../../verdict/src/tests/sum/inputs", 1.0, logger)
-	if status[3].Status != "TLE" {
-		t.Errorf("Expected status TLE but got %s", status[3].Status)
+	if status[3].Status != model.TIME_LIMIT_EXCEEDED {
+		t.Errorf("Expected status %s but got %s", model.TIME_LIMIT_EXCEEDED, status[3].Status)
 	}
 }
 
 func TestExecuteRTE(t *testing.T) {
 	logger := utils.InitDummyLogger()
 	status := Execute("./tests/rte.sh", "../../verdict/src/tests/sum/inputs", 1.0, logger)
-	if status[0].Status != "RTE" {
-		t.Errorf("Expected status RLE but got %s", status[0].Status)
+	if status[0].Status != model.RUNTIME_ERROR {
+		t.Errorf("Expected status %s but got %s", model.RUNTIME_ERROR, status[0].Status)
 	}
 }

--- a/model/model.go
+++ b/model/model.go
@@ -6,6 +6,16 @@ import (
 	"gorm.io/gorm"
 )
 
+const (
+	PENDING               = "Pending"
+	ACCEPTED              = "Accepted"
+	WRONG_ANSWER          = "Wrong Answer"
+	COMPILATION_ERROR     = "Compilation Error"
+	TIME_LIMIT_EXCEEDED   = "Time Limit Exceeded"
+	MEMORY_LIMIT_EXCEEDED = "Memory Limit Exceeded"
+	RUNTIME_ERROR         = "Runtime Error"
+)
+
 // ExecutionResult represents the result of executing a given submission against one test case.
 // TestName is the name of the test case, Status is the status of the test (i.e. "OK", "TLE" nad "RTE")
 // and Message is used to store any relevant information, such as error messages.
@@ -35,11 +45,17 @@ type Challenge struct {
 	Outputs     []TestFile `gorm:"ForeignKey:ChallengeID"`
 }
 
+type Status struct {
+	Verdict string
+	Message string
+}
+
 type Submission struct {
 	gorm.Model
 	ID          uint
 	Language    string
 	Source      []byte
+	Status      Status `gorm:"embedded"`
 	ChallengeID uint
 }
 

--- a/model/model.go
+++ b/model/model.go
@@ -7,6 +7,7 @@ import (
 )
 
 const (
+	REJECTED              = "Rejected"
 	PENDING               = "Pending"
 	ACCEPTED              = "Accepted"
 	WRONG_ANSWER          = "Wrong Answer"

--- a/orm/main.go
+++ b/orm/main.go
@@ -127,7 +127,15 @@ func createOrmServer() *martini.ClassicMartini {
 			utils.WriteResponse(rs, http.StatusInternalServerError, "Error trying to access source file", err)
 			return
 		}
-		submission := model.Submission{Language: form.Language, Source: content, ChallengeID: form.ChallengeID}
+		submission := model.Submission{
+			Language: form.Language,
+			Source:   content,
+			Status: model.Status{
+				Verdict: model.PENDING,
+				Message: "",
+			},
+			ChallengeID: form.ChallengeID,
+		}
 		err = orm.CreateSubmission(&submission)
 		if err != nil {
 			msg := fmt.Sprintf("Could not save submission")

--- a/orm/src/graphql.go
+++ b/orm/src/graphql.go
@@ -2,6 +2,7 @@ package orm
 
 import (
 	"errors"
+	"fmt"
 	"strconv"
 
 	"github.com/graphql-go/graphql"
@@ -72,6 +73,20 @@ var submission = graphql.NewObject(
 					return FindChallenge(submission.ChallengeID)
 				},
 			},
+			"verdict": &graphql.Field{
+				Type: graphql.String,
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					submission := p.Source.(model.Submission)
+					return submission.Status.Verdict, nil
+				},
+			},
+			"message": &graphql.Field{
+				Type: graphql.String,
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					submission := p.Source.(model.Submission)
+					return submission.Status.Message, nil
+				},
+			},
 		},
 	},
 )
@@ -123,8 +138,50 @@ var queries = graphql.NewObject(
 	},
 )
 
+var mutations = graphql.NewObject(
+	graphql.ObjectConfig{
+		Name: "Mutation",
+		Fields: graphql.Fields{
+			"judge": &graphql.Field{
+				Type: submission,
+				Args: graphql.FieldConfigArgument{
+					"submissionID": &graphql.ArgumentConfig{
+						Type: graphql.NewNonNull(graphql.ID),
+					},
+					"verdict": &graphql.ArgumentConfig{
+						Type: graphql.NewNonNull(graphql.String),
+					},
+					"message": &graphql.ArgumentConfig{
+						Type: graphql.String,
+					},
+				},
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					stringSubmissionID := p.Args["submissionID"].(string)
+					submissionID, err := strconv.ParseUint(stringSubmissionID, 10, 64)
+					if err != nil {
+						return nil, errors.New("Could not convert id field to an uint")
+					}
+					verdict := p.Args["verdict"].(string)
+					message := p.Args["message"].(string)
+					submission, err := FindSubmission(uint(submissionID))
+					if err != nil {
+						return nil, errors.New(fmt.Sprintf("Submission with id %v not found ", submissionID))
+					}
+					submission.Status.Verdict = verdict
+					submission.Status.Message = message
+					if err = UpdateSubmission(submission); err != nil {
+						return nil, err
+					}
+					return submission, nil
+				},
+			},
+		},
+	},
+)
+
 var Schema, _ = graphql.NewSchema(
 	graphql.SchemaConfig{
-		Query: queries,
+		Query:    queries,
+		Mutation: mutations,
 	},
 )

--- a/orm/src/orm.go
+++ b/orm/src/orm.go
@@ -72,3 +72,9 @@ func FindSubmission(id uint) (model.Submission, error) {
 	err := db.First(&submission, id).Error
 	return submission, err
 }
+
+// UpdateChallenge receives an existing Submission object and updates its value on the database.
+func UpdateSubmission(submission model.Submission) error {
+	db := dbConnect()
+	return db.Save(&submission).Error
+}

--- a/verdict/src/verdict.go
+++ b/verdict/src/verdict.go
@@ -14,19 +14,19 @@ func compare(expectedOutput string, programOutput string) bool {
 
 // Judge compares the execution output of a submission and the expected output values.
 // Returns a string with the judgment status ("AC", "WA", "TLE" or "RTE") and, possibly, an error.
-func Judge(result []model.ExecutionResult, outputs map[string]string, logger zerolog.Logger) (string, error) {
+func Judge(result []model.ExecutionResult, outputs map[string]string, logger zerolog.Logger) (string, string, error) {
 	for _, testExecution := range result {
 		if testExecution.Status != "OK" {
 			logger.Info().Msg("Judgment finished sentence " + testExecution.Status + " " + testExecution.TestName)
-			return testExecution.Status + " " + testExecution.TestName, nil
+			return testExecution.Status, testExecution.Status + " on test " + testExecution.TestName, nil
 		}
 
 		testName := testExecution.TestName[len("inputs/") : len(testExecution.TestName)-len(".in")]
 		if compare(testExecution.Message, outputs[testName]) == false {
 			logger.Info().Msg("Judgment finished sentence Wrong Answer")
-			return "WA" + " " + testExecution.TestName, nil
+			return model.WRONG_ANSWER, "WA on test " + testExecution.TestName, nil
 		}
 	}
 	logger.Info().Msg("Judgment finished sentence Accepted")
-	return "AC", nil
+	return model.ACCEPTED, "", nil
 }


### PR DESCRIPTION
Now verdict uses `judge` mutation to save verdict and message to a submission.
Add REJECTED status for unexpected errors on submission judging.